### PR TITLE
GPV-743 Use ${ADMIN_USER} instead of hard-coding "gpadmin"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mv TPC-DS-3.0.0 TPC-DS
 
 ## Usage
 
-To run the benchmark, just login as `gpadmin` on `mdw:
+To run the benchmark, login as `gpadmin` on `mdw:
 
 ```
 ssh gpadmin@mdw

--- a/tpcds.sh
+++ b/tpcds.sh
@@ -56,11 +56,11 @@ check_variables() {
 
 check_user() {
   echo "############################################################################"
-  echo "Ensure gpadmin is executing this script."
+  echo "Ensure ${ADMIN_USER} is executing this script."
   echo "############################################################################"
   echo ""
-  if [ "$(whoami)" != "gpadmin" ]; then
-    echo "Script must be executed as gpadmin!"
+  if [ "$(whoami)" != "${ADMIN_USER}" ]; then
+    echo "Script must be executed as ${ADMIN_USER}!"
     exit 1
   fi
 }


### PR DESCRIPTION
- also minor rewording in README.md

Co-authored-by: Xin Zhang <xzhang@vmware.com>
Co-authored-by: Stuart Pollock <stuartp@vmware.com>