### PR TITLE
GPV-743: Fixing ADMIN_USER sourcing issue

### DIFF
--- a/tpcds.sh
+++ b/tpcds.sh
@@ -77,8 +77,8 @@ echo_variables() {
 # Body
 ##################################################################################################################################################
 
-check_user
 check_variables
+check_user
 echo_variables
 
 # run the benchmark


### PR DESCRIPTION
`ADMIN_USER` is not sourced during `check_user()` method which leads to script failure.

Flipped `check_variable()` method first which have necessary sourcing from `tpcds_variables.sh`.

Co-authored-by: Deena Venkatesan <vdeenathayal@vmware.com>
Co-authored-by: Sumit Basumallick <sumitbm@vmware.com>