### PR TITLE
GPV-936 fixing 3 missed scripts that required changes

### DIFF
--- a/02_init/rollout.sh
+++ b/02_init/rollout.sh
@@ -106,17 +106,10 @@ function copy_config()
   psql -v ON_ERROR_STOP=1 -q -A -t -c "SELECT * FROM gp_segment_configuration" -o ${TPC_DS_DIR}/log/gp_segment_configuration.txt
 }
 
-function set_search_path()
-{
-  echo "psql -v ON_ERROR_STOP=1 -q -A -t -c \"ALTER USER ${BENCH_ROLE} SET search_path=${schema_name},public;\""
-  psql -v ON_ERROR_STOP=1 -q -A -t -c "ALTER USER ${BENCH_ROLE} SET search_path=${schema_name},public;"
-}
-
 get_version
 set_segment_bashrc
 check_gucs
 copy_config
-set_search_path
 
 print_log
 

--- a/07_multi_user/rollout.sh
+++ b/07_multi_user/rollout.sh
@@ -26,12 +26,6 @@ rm -f ${TPC_DS_DIR}/log/rollout_testing_*.log
 rm -f ${TPC_DS_DIR}/log/*multi.explain_analyze.log
 rm -f ${PWD}/query_*.sql
 
-if [ "${BENCH_ROLE}" != "gpadmin" ]; then
-	AlterQueue="ALTER RESOURCE QUEUE ${BENCH_ROLE} WITH (ACTIVE_STATEMENTS=$(( MULTI_USER_COUNT + 1 )))"
-	echo "${AlterQueue}"
-	psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${AlterQueue}"
-fi
-
 #create each user's directory
 sql_dir=${PWD}
 echo "sql_dir: ${sql_dir}"

--- a/functions.sh
+++ b/functions.sh
@@ -87,7 +87,7 @@ function source_bashrc() {
     # don't fail if an error is happening in the admin's profile
     source ${HOME}/.bashrc || true
   fi
-  count=$(sed -e 's/#.*$//' ${HOME}/.bashrc | grep -c "greenplum_path")
+  count=$(egrep -c "source .*/greenplum_path.sh|\. .*/greenplum_path.sh" ${HOME}/.bashrc)
   if [ ${count} -eq 0 ]; then
       echo "${HOME}/.bashrc does not contain greenplum_path.sh"
       echo "Please update your ${startup_file} for ${ADMIN_USER} and try again."


### PR DESCRIPTION
- updated the the way source_bashrc() in functions.sh counted
  sourced greenplum environments
- removed set_search_path() from 02_init/rollout.sh
- removed alter resource queue from 07_multi_user/rollout.sh

Co-authored-by: Xin Zhang <zhxin@vmware.com>
Co-authored-by: Gaurab Dey <gaurabd@vmware.com>
Co-authored-by: Richard Gostanian <rgostanian@vmware.com>
Co-authored-by: Mike Nemesh <nemeshm@vmware.com>