### PR TITLE
GPV-1183 speed-up TPC-DS rollout on cluster with large number of nodes

### DIFF
--- a/00_compile_tpcds/rollout.sh
+++ b/00_compile_tpcds/rollout.sh
@@ -30,8 +30,9 @@ function copy_tpc()
   #copy the compiled dsdgen program to the segment nodes
   echo "copy tpcds binaries to segment hosts"
   for i in $(cat ${TPC_DS_DIR}/segment_hosts.txt); do
-    scp tools/dsdgen tools/tpcds.idx ${i}:
+    scp tools/dsdgen tools/tpcds.idx ${i}: &
   done
+  wait
 }
 
 function copy_queries()

--- a/01_gen_data/rollout.sh
+++ b/01_gen_data/rollout.sh
@@ -26,15 +26,17 @@ function kill_orphaned_data_gen() {
   echo "kill any orphaned dsdgen processes on segment hosts"
   # always return true even if no processes were killed
   for i in $(cat ${TPC_DS_DIR}/segment_hosts.txt); do
-    ssh ${i} "pkill dsdgen" || true
+    ssh ${i} "pkill dsdgen" || true &
   done
+  wait
 }
 
 function copy_generate_data() {
   echo "copy generate_data.sh to segment hosts"
   for i in $(cat ${TPC_DS_DIR}/segment_hosts.txt); do
-    scp ${PWD}/generate_data.sh ${i}:
+    scp ${PWD}/generate_data.sh ${i}: &
   done
+  wait
 }
 
 function gen_data() {
@@ -57,8 +59,9 @@ function gen_data() {
     GEN_DATA_PATH="${GEN_DATA_PATH}/dsbenchmark"
     echo "ssh -n -f ${EXT_HOST} \"bash -c \'cd ~/; ./generate_data.sh ${GEN_DATA_SCALE} ${CHILD} ${PARALLEL} ${GEN_DATA_PATH} &> generate_data.${CHILD}.log &\'\""
 
-    ssh -n -f ${EXT_HOST} "bash -c 'cd ~/; ./generate_data.sh ${GEN_DATA_SCALE} ${CHILD} ${PARALLEL} ${GEN_DATA_PATH} &> generate_data.${CHILD}.log &'"
+    ssh -n -f ${EXT_HOST} "bash -c 'cd ~/; ./generate_data.sh ${GEN_DATA_SCALE} ${CHILD} ${PARALLEL} ${GEN_DATA_PATH} &> generate_data.${CHILD}.log &'" &
   done
+  wait
 }
 
 step="gen_data"

--- a/04_load/rollout.sh
+++ b/04_load/rollout.sh
@@ -14,16 +14,18 @@ function copy_script()
   echo "copy the start and stop scripts to the segment hosts in the cluster"
   for i in $(cat ${TPC_DS_DIR}/segment_hosts.txt); do
     echo "scp start_gpfdist.sh stop_gpfdist.sh ${i}:"
-    scp ${PWD}/start_gpfdist.sh ${PWD}/stop_gpfdist.sh ${i}:
+    scp ${PWD}/start_gpfdist.sh ${PWD}/stop_gpfdist.sh ${i}: &
   done
+  wait
 }
 
 function stop_gpfdist()
 {
   echo "stop gpfdist on all ports"
   for i in $(cat ${TPC_DS_DIR}/segment_hosts.txt); do
-    ssh -n -f $i "bash -c 'cd ~/; ./stop_gpfdist.sh'"
+    ssh -n -f $i "bash -c 'cd ~/; ./stop_gpfdist.sh'" &
   done
+  wait
 }
 
 function start_gpfdist()
@@ -43,9 +45,9 @@ function start_gpfdist()
     GEN_DATA_PATH="${GEN_DATA_PATH}/dsbenchmark"
     PORT=$((GPFDIST_PORT + CHILD))
     echo "executing on ${EXT_HOST} ./start_gpfdist.sh $PORT ${GEN_DATA_PATH}"
-    ssh -n -f ${EXT_HOST} "bash -c 'cd ~${ADMIN_USER}; ./start_gpfdist.sh $PORT ${GEN_DATA_PATH}'"
-    sleep 1
+    ssh -n -f ${EXT_HOST} "bash -c 'cd ~${ADMIN_USER}; ./start_gpfdist.sh $PORT ${GEN_DATA_PATH}'" &
   done
+  wait
 }
 
 copy_script

--- a/tpcds_tools/tpcds_cleanup.sh
+++ b/tpcds_tools/tpcds_cleanup.sh
@@ -14,5 +14,6 @@ echo "Cleaning multi-user sql scripts(default 5CU): 07_multi_user/[1-5]"
 rm -rf ${HOME}/TPC-DS/07_multi_user/[1-5]
 echo "Cleaning all tpcds remnents from segment nodes: binary, logs, data, etc."
 for i in $(cat ${HOME}/segment_hosts.txt); do
-  ssh ${i} 'rm -f dsdgen generate_data.*.log generate_data.sh gpfdist.*.log hosts-all hosts-segments start_gpfdist.sh stop_gpfdist.sh tpcds.idx; find /gpdata -type d -name dsbenchmark -exec rm -rf {} \;'
+  ssh ${i} 'rm -f dsdgen generate_data.*.log generate_data.sh gpfdist.*.log hosts-all hosts-segments start_gpfdist.sh stop_gpfdist.sh tpcds.idx; find /gpdata -type d -name dsbenchmark -exec rm -rf {} \;' &
 done
+wait


### PR DESCRIPTION
The current script sequentially iterate through all the nodes. When we have very large number of nodes, it take a very long time to roll-out the scripts.

We parallelize the iteration to speed-up the process.

Authored-by: Xin Zhang <zhxin@vmware.com>