### PR TITLE
GPV-1126 Fix the GBB validation scripts on mirrorless deployments

### DIFF
--- a/tpcds_tools/validate_gbb.sh
+++ b/tpcds_tools/validate_gbb.sh
@@ -194,7 +194,34 @@ validate_guc_settings() {
 		mem_factor=117
 	fi
 	gp_vmem=$(( (((SWAP_IN_MB + RAM_IN_MB) - (7680 + (5 / 100) * RAM_IN_MB)) / (mem_factor / 100)) ))
-	max_acting_primary_segments=$(su - gpadmin -c "psql -d postgres -t -c \"with hostnames as ( select distinct hostname from gp_segment_configuration where content <> -1 order by hostname limit 1), content_ids as ( select content from gp_segment_configuration where hostname in ( select hostname from hostnames ) and preferred_role = 'p' and content <> -1), counts as ( select count(content) as mirrors_per_host, hostname from gp_segment_configuration where content in (select content from content_ids) and preferred_role = 'm' group by hostname) select count(content) + max(mirrors_per_host) as max_acting_primary_segments from content_ids, counts\"" | awk '{ printf $1 }')
+	max_acting_primary_segments=$(su - gpadmin -c "psql -d postgres -t -c \
+		\"with hostnames as ( \
+			select distinct hostname \
+			from gp_segment_configuration \
+			where content <> -1 order by hostname \
+			limit 1), \
+		content_ids as ( \
+			select content \
+			from gp_segment_configuration \
+			where hostname in ( \
+					select hostname \
+					from hostnames ) \
+				and preferred_role = 'p' \
+				and content <> -1), \
+		counts as ( \
+			select count(content) as mirrors_per_host, hostname \
+			from gp_segment_configuration \
+			where content in ( \
+					select content \
+					from content_ids) \
+				and preferred_role = 'm' \
+			group by hostname) \
+		select t.count + coalesce(s.max, 0) \
+		from ( \
+			select count(content) \
+			from content_ids) t, ( \
+			select max(mirrors_per_host) \
+			from counts) s\"" | awk '{ printf $1 }')
 	gp_vmem_protect_limit=$(( gp_vmem / max_acting_primary_segments ))
 
 	cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_interconnect_queue_depth'" "Master  value: 16"


### PR DESCRIPTION
- the original psql script depends on existence of mirror
- we fix to make it 0 if mirror is missing
- also format the code in a way easier to ready on the long query

Co-authored-by: Xin Zhang <zhxin@vmware.com>
Co-authored-by: Richard Gostanian <rgostanian@vmware.com>