### PR TITLE
GPV-1364: Update psql to use PSQL_OPTIONS

### DIFF
--- a/01_gen_data/rollout.sh
+++ b/01_gen_data/rollout.sh
@@ -52,7 +52,7 @@ function gen_data() {
   else
     SQL_QUERY="select row_number() over(), g.hostname, p.fselocation as path from gp_segment_configuration g join pg_filespace_entry p on g.dbid = p.fsedbid join pg_tablespace t on t.spcfsoid = p.fsefsoid where g.content >= 0 and g.role = '${GPFDIST_LOCATION}' and t.spcname = 'pg_default' order by 1, 2, 3"
   fi
-  for i in $(psql -v ON_ERROR_STOP=1 -q -A -t -c "${SQL_QUERY}"); do
+  for i in $(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -A -t -c "${SQL_QUERY}"); do
     CHILD=$(echo ${i} | awk -F '|' '{print $1}')
     EXT_HOST=$(echo ${i} | awk -F '|' '{print $2}')
     GEN_DATA_PATH=$(echo ${i} | awk -F '|' '{print $3}')

--- a/02_init/rollout.sh
+++ b/02_init/rollout.sh
@@ -50,7 +50,7 @@ function check_gucs() {
 
   if [ "${VERSION}" == "gpdb_5" ]; then
     counter=$(
-      psql -v ON_ERROR_STOP=1 -q -t -A -c "show optimizer_join_arity_for_associativity_commutativity" | grep -i "18" | wc -l
+      psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "show optimizer_join_arity_for_associativity_commutativity" | grep -i "18" | wc -l
       exit ${PIPESTATUS[0]}
     )
     if [ "${counter}" -eq "0" ]; then
@@ -62,7 +62,7 @@ function check_gucs() {
 
   echo "check optimizer"
   counter=$(
-    psql -v ON_ERROR_STOP=1 -q -t -A -c "show optimizer" | grep -i "on" | wc -l
+    psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "show optimizer" | grep -i "on" | wc -l
     exit ${PIPESTATUS[0]}
   )
   if [ "${counter}" -eq "0" ]; then
@@ -73,7 +73,7 @@ function check_gucs() {
 
   echo "check analyze_root_partition"
   counter=$(
-    psql -v ON_ERROR_STOP=1 -q -t -A -c "show optimizer_analyze_root_partition" | grep -i "on" | wc -l
+    psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "show optimizer_analyze_root_partition" | grep -i "on" | wc -l
     exit ${PIPESTATUS[0]}
   )
   if [ "${counter}" -eq "0" ]; then
@@ -84,7 +84,7 @@ function check_gucs() {
 
   echo "check gp_autostats_mode"
   counter=$(
-    psql -v ON_ERROR_STOP=1 -q -t -A -c "show gp_autostats_mode" | grep -i "none" | wc -l
+    psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "show gp_autostats_mode" | grep -i "none" | wc -l
     exit ${PIPESTATUS[0]}
   )
   if [ "${counter}" -eq "0" ]; then
@@ -95,7 +95,7 @@ function check_gucs() {
 
   echo "check default_statistics_target"
   counter=$(
-    psql -v ON_ERROR_STOP=1 -q -t -A -c "show default_statistics_target" | grep "100" | wc -l
+    psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "show default_statistics_target" | grep "100" | wc -l
     exit ${PIPESTATUS[0]}
   )
   if [ "${counter}" -eq "0" ]; then
@@ -117,7 +117,7 @@ function copy_config() {
     cp ${MASTER_DATA_DIRECTORY}/postgresql.conf ${TPC_DS_DIR}/log/
   fi
   #gp_segment_configuration
-  psql -v ON_ERROR_STOP=1 -q -A -t -c "SELECT * FROM gp_segment_configuration" -o ${TPC_DS_DIR}/log/gp_segment_configuration.txt
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -A -t -c "SELECT * FROM gp_segment_configuration" -o "${TPC_DS_DIR}"/log/gp_segment_configuration.txt
 }
 
 get_version

--- a/03_ddl/rollout.sh
+++ b/03_ddl/rollout.sh
@@ -32,8 +32,8 @@ if [ "${DROP_EXISTING_TABLES}" == "true" ]; then
       DISTRIBUTED_BY="DISTRIBUTED BY (${distribution})"
     fi
 
-    log_time "psql -v ON_ERROR_STOP=1 -q -a -P pager=off -f ${i} -v SMALL_STORAGE=\"${SMALL_STORAGE}\" -v MEDIUM_STORAGE=\"${MEDIUM_STORAGE}\" -v LARGE_STORAGE=\"${LARGE_STORAGE}\" -v DISTRIBUTED_BY=\"${DISTRIBUTED_BY}\""
-    psql -v ON_ERROR_STOP=1 -q -a -P pager=off -f ${i} -v SMALL_STORAGE="${SMALL_STORAGE}" -v MEDIUM_STORAGE="${MEDIUM_STORAGE}" -v LARGE_STORAGE="${LARGE_STORAGE}" -v DISTRIBUTED_BY="${DISTRIBUTED_BY}"
+    log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -a -P pager=off -f ${i} -v SMALL_STORAGE=\"${SMALL_STORAGE}\" -v MEDIUM_STORAGE=\"${MEDIUM_STORAGE}\" -v LARGE_STORAGE=\"${LARGE_STORAGE}\" -v DISTRIBUTED_BY=\"${DISTRIBUTED_BY}\""
+    psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -a -P pager=off -f ${i} -v SMALL_STORAGE="${SMALL_STORAGE}" -v MEDIUM_STORAGE="${MEDIUM_STORAGE}" -v LARGE_STORAGE="${LARGE_STORAGE}" -v DISTRIBUTED_BY="${DISTRIBUTED_BY}"
 
     print_log
   done
@@ -55,7 +55,7 @@ if [ "${DROP_EXISTING_TABLES}" == "true" ]; then
     else
       SQL_QUERY="select rank() over (partition by g.hostname order by p.fselocation), g.hostname from gp_segment_configuration g join pg_filespace_entry p on g.dbid = p.fsedbid join pg_tablespace t on t.spcfsoid = p.fsefsoid where g.content >= 0 and g.role = '${GPFDIST_LOCATION}' and t.spcname = 'pg_default' order by g.hostname"
     fi
-    for x in $(psql -v ON_ERROR_STOP=1 -q -A -t -c "${SQL_QUERY}"); do
+    for x in $(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -A -t -c "${SQL_QUERY}"); do
       CHILD=$(echo ${x} | awk -F '|' '{print $1}')
       EXT_HOST=$(echo ${x} | awk -F '|' '{print $2}')
       PORT=$((GPFDIST_PORT + CHILD))
@@ -71,8 +71,8 @@ if [ "${DROP_EXISTING_TABLES}" == "true" ]; then
     done
     LOCATION+="'"
 
-    log_time "psql -v ON_ERROR_STOP=1 -q -a -P pager=off -f ${i} -v LOCATION=\"${LOCATION}\""
-    psql -v ON_ERROR_STOP=1 -q -a -P pager=off -f ${i} -v LOCATION="${LOCATION}"
+    log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -a -P pager=off -f ${i} -v LOCATION=\"${LOCATION}\""
+    psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -a -P pager=off -f ${i} -v LOCATION="${LOCATION}"
 
     print_log
   done
@@ -88,17 +88,17 @@ start_log
 
 if [ "${BENCH_ROLE}" != "gpadmin" ]; then
   log_time "Drop role ${BENCH_ROLE}"
-  psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${DropRole}"
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=0 -q -P pager=off -c "${DropRole}"
   log_time "Creating role ${BENCH_ROLE}"
-  psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${CreateRole}"
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=0 -q -P pager=off -c "${CreateRole}"
   log_time "Grant schema privileges to role ${BENCH_ROLE}"
-  psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${GrantSchemaPrivileges}"
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=0 -q -P pager=off -c "${GrantSchemaPrivileges}"
   log_time "Grant table privileges to role ${BENCH_ROLE}"
-  psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${GrantTablePrivileges}"
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=0 -q -P pager=off -c "${GrantTablePrivileges}"
 fi
 
 log_time "Set search_path for database gpadmin"
-psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${SetSearchPath}"
+psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=0 -q -P pager=off -c "${SetSearchPath}"
 
 print_log
 

--- a/04_load/analyze.sh
+++ b/04_load/analyze.sh
@@ -30,21 +30,21 @@ if [ "$return_status" -eq "0" ]; then
   print_log ${tuples}
 else
   #get stats on all non-partitioned tables and all partitions
-  for i in $(psql -A -t -v ON_ERROR_STOP=ON -c "SELECT lpad(row_number() over() + $max_id, 3, '0') || '.' || n.nspname || '.' || c.relname FROM pg_class c JOIN pg_namespace n on c.relnamespace = n.oid WHERE n.nspname = 'tpcds' AND c.relname NOT IN (SELECT DISTINCT tablename FROM pg_partitions p WHERE schemaname = 'tpcds') AND c.reltuples::bigint = 0"); do
+  for i in $(psql ${PSQL_OPTIONS} -A -t -v ON_ERROR_STOP=ON -c "SELECT lpad(row_number() over() + $max_id, 3, '0') || '.' || n.nspname || '.' || c.relname FROM pg_class c JOIN pg_namespace n on c.relnamespace = n.oid WHERE n.nspname = 'tpcds' AND c.relname NOT IN (SELECT DISTINCT tablename FROM pg_partitions p WHERE schemaname = 'tpcds') AND c.reltuples::bigint = 0"); do
 
     start_log
     id=$(echo ${i} | awk -F '.' '{print $1}')
     schema_name=$(echo ${i} | awk -F '.' '{print $2}')
     table_name=$(echo ${i} | awk -F '.' '{print $3}')
 
-    log_time "psql -a -v ON_ERROR_STOP=ON -c \"ANALYZE ${schema_name}.${table_name}\""
-    psql -a -v ON_ERROR_STOP=ON -c "ANALYZE ${schema_name}.${table_name}"
+    log_time "psql ${PSQL_OPTIONS} -a -v ON_ERROR_STOP=ON -c \"ANALYZE ${schema_name}.${table_name}\""
+    psql ${PSQL_OPTIONS} -a -v ON_ERROR_STOP=ON -c "ANALYZE ${schema_name}.${table_name}"
     tuples="0"
     print_log ${tuples}
   done
 
   #analyze root partitions of partitioned tables
-  for i in $(psql -A -t -v ON_ERROR_STOP=ON -c "SELECT lpad(row_number() over() + $max_id, 3, '0') || '.' || n.nspname || '.' || c.relname FROM pg_class c JOIN pg_namespace n on c.relnamespace = n.oid WHERE n.nspname = 'tpcds' AND c.relname IN (SELECT DISTINCT tablename FROM pg_partitions p WHERE schemaname = 'tpcds') AND c.reltuples::bigint = 0"); do
+  for i in $(psql ${PSQL_OPTIONS} -A -t -v ON_ERROR_STOP=ON -c "SELECT lpad(row_number() over() + $max_id, 3, '0') || '.' || n.nspname || '.' || c.relname FROM pg_class c JOIN pg_namespace n on c.relnamespace = n.oid WHERE n.nspname = 'tpcds' AND c.relname IN (SELECT DISTINCT tablename FROM pg_partitions p WHERE schemaname = 'tpcds') AND c.reltuples::bigint = 0"); do
     start_log
 
     id=$(echo ${i} | awk -F '.' '{print $1}')
@@ -52,8 +52,8 @@ else
     schema_name=$(echo ${i} | awk -F '.' '{print $2}')
     table_name=$(echo ${i} | awk -F '.' '{print $3}')
 
-    log_time "psql -a -v ON_ERROR_STOP=ON -c \"ANALYZE ROOTPARTITION ${schema_name}.${table_name}\""
-    psql -a -v ON_ERROR_STOP=ON -c "ANALYZE ROOTPARTITION ${schema_name}.${table_name}"
+    log_time "psql ${PSQL_OPTIONS} -a -v ON_ERROR_STOP=ON -c \"ANALYZE ROOTPARTITION ${schema_name}.${table_name}\""
+    psql ${PSQL_OPTIONS} -a -v ON_ERROR_STOP=ON -c "ANALYZE ROOTPARTITION ${schema_name}.${table_name}"
     tuples="0"
     print_log ${tuples}
   done

--- a/04_load/rollout.sh
+++ b/04_load/rollout.sh
@@ -35,7 +35,7 @@ function start_gpfdist() {
   else
     SQL_QUERY="select rank() over (partition by g.hostname order by p.fselocation), g.hostname, p.fselocation as path from gp_segment_configuration g join pg_filespace_entry p on g.dbid = p.fsedbid join pg_tablespace t on t.spcfsoid = p.fsefsoid where g.content >= 0 and g.role = '${GPFDIST_LOCATION}' and t.spcname = 'pg_default' order by g.hostname"
   fi
-  for i in $(psql -v ON_ERROR_STOP=1 -q -A -t -c "${SQL_QUERY}"); do
+  for i in $(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -A -t -c "${SQL_QUERY}"); do
     CHILD=$(echo ${i} | awk -F '|' '{print $1}')
     EXT_HOST=$(echo ${i} | awk -F '|' '{print $2}')
     GEN_DATA_PATH=$(echo ${i} | awk -F '|' '{print $3}')
@@ -61,9 +61,9 @@ for i in ${PWD}/*.${filter}.*.sql; do
   schema_name=$(echo ${i} | awk -F '.' '{print $2}')
   table_name=$(echo ${i} | awk -F '.' '{print $3}')
 
-  log_time "psql -v ON_ERROR_STOP=1 -f ${i} | grep INSERT | awk -F ' ' '{print \$3}'"
+  log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -f ${i} | grep INSERT | awk -F ' ' '{print \$3}'"
   tuples=$(
-    psql -v ON_ERROR_STOP=1 -f ${i} | grep INSERT | awk -F ' ' '{print $3}'
+    psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -f ${i} | grep INSERT | awk -F ' ' '{print $3}'
     exit ${PIPESTATUS[0]}
   )
 
@@ -101,13 +101,13 @@ if [ "${VERSION}" == "gpdb_6" ]; then
 else
   SQL_QUERY="select n.nspname, c.relname from pg_class c join pg_namespace n on c.relnamespace = n.oid join pg_partitions p on p.schemaname = n.nspname and p.tablename = c.relname where n.nspname = 'tpcds' and p.partitionrank is null and c.reltuples = 0 order by 1, 2"
 fi
-for t in $(psql -v ON_ERROR_STOP=1 -q -t -A -c "${SQL_QUERY}"); do
+for t in $(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "${SQL_QUERY}"); do
   schema_name=$(echo ${t} | awk -F '|' '{print $1}')
   table_name=$(echo ${t} | awk -F '|' '{print $2}')
   echo "Missing root stats for ${schema_name}.${table_name}"
   SQL_QUERY="ANALYZE ROOTPARTITION ${schema_name}.${table_name}"
-  log_time "psql -v ON_ERROR_STOP=1 -q -t -A -c \"${SQL_QUERY}\""
-  psql -v ON_ERROR_STOP=1 -q -t -A -c "${SQL_QUERY}"
+  log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c \"${SQL_QUERY}\""
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "${SQL_QUERY}"
 done
 
 tuples="0"

--- a/05_sql/rollout.sh
+++ b/05_sql/rollout.sh
@@ -17,16 +17,16 @@ for i in ${PWD}/*.${BENCH_ROLE}.*.sql; do
     export table_name
     start_log
     if [ "${EXPLAIN_ANALYZE}" == "false" ]; then
-      log_time "psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"\" -f ${i} | wc -l"
+      log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"\" -f ${i} | wc -l"
       tuples=$(
-        psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l
+        psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l
         exit ${PIPESTATUS[0]}
       )
     else
       myfilename=$(basename ${i})
       mylogfile=${TPC_DS_DIR}/log/${myfilename}.single.explain_analyze.log
-      log_time "psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i} > ${mylogfile}"
-      psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f ${i} > ${mylogfile}
+      log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i} > ${mylogfile}"
+      psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f ${i} > ${mylogfile}
       tuples="0"
     fi
     print_log ${tuples}

--- a/06_single_user_reports/rollout.sh
+++ b/06_single_user_reports/rollout.sh
@@ -10,8 +10,8 @@ init_log ${step}
 filter="gpdb"
 
 for i in ${PWD}/*.${filter}.*.sql; do
-  log_time "psql -v ON_ERROR_STOP=1 -a -f ${i}"
-  psql -v ON_ERROR_STOP=1 -a -f ${i}
+  log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -a -f ${i}"
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -a -f ${i}
   echo ""
 done
 
@@ -19,32 +19,32 @@ for i in ${PWD}/*.copy.*.sql; do
   logstep=$(echo ${i} | awk -F 'copy.' '{print $2}' | awk -F '.' '{print $1}')
   logfile="${TPC_DS_DIR}/log/rollout_${logstep}.log"
   logfile="'${logfile}'"
-  log_time "psql -v ON_ERROR_STOP=1 -a -f ${i} -v LOGFILE=\"${logfile}\""
-  psql -v ON_ERROR_STOP=1 -a -f ${i} -v LOGFILE="${logfile}"
+  log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -a -f ${i} -v LOGFILE=\"${logfile}\""
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -a -f ${i} -v LOGFILE="${logfile}"
   echo ""
 done
 
-psql -v ON_ERROR_STOP=1 -q -t -A -c "select 'analyze ' || n.nspname || '.' || c.relname || ';' from pg_class c join pg_namespace n on n.oid = c.relnamespace and n.nspname = 'tpcds_reports'" | psql -v ON_ERROR_STOP=1 -t -A -e
+psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select 'analyze ' || n.nspname || '.' || c.relname || ';' from pg_class c join pg_namespace n on n.oid = c.relnamespace and n.nspname = 'tpcds_reports'" | psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -t -A -e
 
 echo "********************************************************************************"
 echo "Generate Data"
 echo "********************************************************************************"
-psql -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f ${PWD}/gen_data_report.sql
+psql ${PSQL_OPTIONS} -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f ${PWD}/gen_data_report.sql
 echo ""
 echo "********************************************************************************"
 echo "Data Loads"
 echo "********************************************************************************"
-psql -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f ${PWD}/loads_report.sql
+psql ${PSQL_OPTIONS} -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f ${PWD}/loads_report.sql
 echo ""
 echo "********************************************************************************"
 echo "Analyze"
 echo "********************************************************************************"
-psql -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f ${PWD}/analyze_report.sql
+psql ${PSQL_OPTIONS} -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f ${PWD}/analyze_report.sql
 echo ""
 echo ""
 echo "********************************************************************************"
 echo "Queries"
 echo "********************************************************************************"
-psql -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f ${PWD}/queries_report.sql
+psql ${PSQL_OPTIONS} -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f ${PWD}/queries_report.sql
 echo ""
 echo "Finished ${step}"

--- a/08_multi_user_reports/rollout.sh
+++ b/08_multi_user_reports/rollout.sh
@@ -10,8 +10,8 @@ get_version
 filter="gpdb"
 
 for i in ${PWD}/*.${filter}.*.sql; do
-  log_time "psql -v ON_ERROR_STOP=1 -a -f ${i}"
-  psql -v ON_ERROR_STOP=1 -a -f ${i}
+  log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -a -f ${i}"
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -a -f ${i}
   echo ""
 done
 
@@ -19,13 +19,13 @@ filename=$(ls ${PWD}/*.copy.*.sql)
 
 for i in ${TPC_DS_DIR}/log/rollout_testing_*; do
   logfile="'${i}'"
-  log_time "psql -v ON_ERROR_STOP=1 -a -f ${filename} -v LOGFILE=\"${logfile}\""
-  psql -v ON_ERROR_STOP=1 -a -f ${filename} -v LOGFILE="${logfile}"
+  log_time "psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -a -f ${filename} -v LOGFILE=\"${logfile}\""
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -a -f ${filename} -v LOGFILE="${logfile}"
 done
 
-psql -v ON_ERROR_STOP=1 -t -A -c "select 'analyze ' || n.nspname || '.' || c.relname || ';' from pg_class c join pg_namespace n on n.oid = c.relnamespace and n.nspname = 'tpcds_testing'" | psql -v ON_ERROR_STOP=1 -t -A -e
+psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -t -A -c "select 'analyze ' || n.nspname || '.' || c.relname || ';' from pg_class c join pg_namespace n on n.oid = c.relnamespace and n.nspname = 'tpcds_testing'" | psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -t -A -e
 
-psql -v ON_ERROR_STOP=1 -F $'\t' -A -P pager=off -f ${PWD}/detailed_report.sql
+psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -F $'\t' -A -P pager=off -f ${PWD}/detailed_report.sql
 echo ""
 
 echo "Finished ${step}"

--- a/09_score/rollout.sh
+++ b/09_score/rollout.sh
@@ -6,11 +6,11 @@ PWD=$(get_pwd ${BASH_SOURCE[0]})
 step="score"
 init_log ${step}
 
-LOAD_TIME=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select round(sum(extract('epoch' from duration))) from tpcds_reports.load where tuples > 0")
-ANALYZE_TIME=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select round(sum(extract('epoch' from duration))) from tpcds_reports.load where tuples = 0")
-QUERIES_TIME=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select round(sum(extract('epoch' from duration))) from (SELECT split_part(description, '.', 2) AS id, min(duration) AS duration FROM tpcds_reports.sql GROUP BY split_part(description, '.', 2)) as sub")
-CONCURRENT_QUERY_TIME=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select round(sum(extract('epoch' from duration))) from tpcds_testing.sql")
-THROUGHPUT_ELAPSED_TIME=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select max(end_epoch_seconds) - min(start_epoch_seconds) from tpcds_testing.sql")
+LOAD_TIME=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select round(sum(extract('epoch' from duration))) from tpcds_reports.load where tuples > 0")
+ANALYZE_TIME=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select round(sum(extract('epoch' from duration))) from tpcds_reports.load where tuples = 0")
+QUERIES_TIME=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select round(sum(extract('epoch' from duration))) from (SELECT split_part(description, '.', 2) AS id, min(duration) AS duration FROM tpcds_reports.sql GROUP BY split_part(description, '.', 2)) as sub")
+CONCURRENT_QUERY_TIME=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select round(sum(extract('epoch' from duration))) from tpcds_testing.sql")
+THROUGHPUT_ELAPSED_TIME=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select max(end_epoch_seconds) - min(start_epoch_seconds) from tpcds_testing.sql")
 
 S_Q=${MULTI_USER_COUNT}
 SF=${GEN_DATA_SCALE}
@@ -23,13 +23,13 @@ TLD_1_3_1=$((S_Q * LOAD_TIME / 100))
 
 # Calculate operands for v2.2.0 of the TPC-DS score
 Q_2_2_0=$((S_Q * 99))
-TPT_2_2_0=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select cast(${QUERIES_TIME} as decimal) * cast(${S_Q} as decimal) / cast(3600.0 as decimal)")
-TTT_2_2_0=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select cast(2 as decimal) * cast(${THROUGHPUT_ELAPSED_TIME} as decimal) / cast(3600.0 as decimal)")
-TLD_2_2_0=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select cast(0.01 as decimal) * cast(${S_Q} as decimal) * cast(${LOAD_TIME} as decimal) / cast(3600.0 as decimal)")
+TPT_2_2_0=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select cast(${QUERIES_TIME} as decimal) * cast(${S_Q} as decimal) / cast(3600.0 as decimal)")
+TTT_2_2_0=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select cast(2 as decimal) * cast(${THROUGHPUT_ELAPSED_TIME} as decimal) / cast(3600.0 as decimal)")
+TLD_2_2_0=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select cast(0.01 as decimal) * cast(${S_Q} as decimal) * cast(${LOAD_TIME} as decimal) / cast(3600.0 as decimal)")
 
 # Calculate scores using aggregation functions in psql
-SCORE_1_3_1=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select floor(cast(${Q_1_3_1} as decimal) * cast(${SF} as decimal) / (cast(${TPT_1_3_1} as decimal) + cast(${TTT_1_3_1} as decimal) + cast(${TLD_1_3_1} as decimal)))")
-SCORE_2_2_0=$(psql -v ON_ERROR_STOP=1 -q -t -A -c "select floor(cast(${Q_2_2_0} as decimal) * cast(${SF} as decimal) / exp((ln(cast(${TPT_2_2_0} as decimal)) + ln(cast(${TTT_2_2_0} as decimal)) + ln(cast(${TLD_2_2_0} as decimal))) / cast(3.0 as decimal)))")
+SCORE_1_3_1=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select floor(cast(${Q_1_3_1} as decimal) * cast(${SF} as decimal) / (cast(${TPT_1_3_1} as decimal) + cast(${TTT_1_3_1} as decimal) + cast(${TLD_1_3_1} as decimal)))")
+SCORE_2_2_0=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -q -t -A -c "select floor(cast(${Q_2_2_0} as decimal) * cast(${SF} as decimal) / exp((ln(cast(${TPT_2_2_0} as decimal)) + ln(cast(${TTT_2_2_0} as decimal)) + ln(cast(${TLD_2_2_0} as decimal))) / cast(3.0 as decimal)))")
 
 printf "Number of Streams (Sq)\t%d\n" "${S_Q}"
 printf "Scale Factor (SF)\t%d\n" "${SF}"

--- a/functions.sh
+++ b/functions.sh
@@ -123,7 +123,7 @@ function get_pwd() {
 export -f get_pwd
 
 function get_gpfdist_port() {
-  all_ports=$(psql -t -A -c "select min(case when role = 'p' then port else 999999 end), min(case when role = 'm' then port else 999999 end) from gp_segment_configuration where content >= 0")
+  all_ports=$(psql ${PSQL_OPTIONS} -t -A -c "select min(case when role = 'p' then port else 999999 end), min(case when role = 'm' then port else 999999 end) from gp_segment_configuration where content >= 0")
   primary_base=$(echo ${all_ports} | awk -F '|' '{print $1}' | head -c1)
   mirror_base=$(echo $all_ports | awk -F '|' '{print $2}' | head -c1)
 
@@ -139,9 +139,9 @@ export -f get_gpfdist_port
 
 function get_version() {
   #need to call source_bashrc first
-  VERSION=$(psql -v ON_ERROR_STOP=1 -t -A -c "SELECT CASE WHEN POSITION ('Greenplum Database 4.3' IN version) > 0 THEN 'gpdb_4_3' WHEN POSITION ('Greenplum Database 5' IN version) > 0 THEN 'gpdb_5' WHEN POSITION ('Greenplum Database 6' IN version) > 0 THEN 'gpdb_6' ELSE 'postgresql' END FROM version();")
+  VERSION=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -t -A -c "SELECT CASE WHEN POSITION ('Greenplum Database 4.3' IN version) > 0 THEN 'gpdb_4_3' WHEN POSITION ('Greenplum Database 5' IN version) > 0 THEN 'gpdb_5' WHEN POSITION ('Greenplum Database 6' IN version) > 0 THEN 'gpdb_6' ELSE 'postgresql' END FROM version();")
   if [[ ${VERSION} =~ "gpdb" ]]; then
-    quicklz_test=$(psql -v ON_ERROR_STOP=1 -t -A -c "SELECT COUNT(1) FROM pg_compression WHERE compname = 'quicklz'")
+    quicklz_test=$(psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -t -A -c "SELECT COUNT(1) FROM pg_compression WHERE compname = 'quicklz'")
     if [ "${quicklz_test}" -eq "1" ]; then
       SMALL_STORAGE="appendonly=true, orientation=column"
       MEDIUM_STORAGE="appendonly=true, orientation=column"
@@ -217,6 +217,6 @@ function create_hosts_file() {
   # get_version
 
   SQL_QUERY="SELECT DISTINCT hostname FROM gp_segment_configuration WHERE role = '${GPFDIST_LOCATION}' AND content >= 0"
-  psql -v ON_ERROR_STOP=1 -t -A -c "${SQL_QUERY}" -o ${TPC_DS_DIR}/segment_hosts.txt
+  psql ${PSQL_OPTIONS} -v ON_ERROR_STOP=1 -t -A -c "${SQL_QUERY}" -o ${TPC_DS_DIR}/segment_hosts.txt
 }
 export -f create_hosts_file

--- a/tpcds_tools/tpcds_get_gucs.sh
+++ b/tpcds_tools/tpcds_get_gucs.sh
@@ -37,4 +37,4 @@ gpconfig -s gp_resqueue_priority
 gpconfig -s gp_resqueue_priority_cpucores_per_segment
 gpconfig -s gp_resqueue_priority_sweeper_interval
 
-psql -c "SELECT * FROM gp_toolkit.gp_resgroup_config order by groupid" template1
+psql ${PSQL_OPTIONS} -c "SELECT * FROM gp_toolkit.gp_resgroup_config order by groupid" template1

--- a/tpcds_tools/tpcds_set_gucs.sh
+++ b/tpcds_tools/tpcds_set_gucs.sh
@@ -17,4 +17,4 @@ gpconfig -c gp_interconnect_snd_queue_depth -v 16
 # gpconfig -c gp_dispatch_keepalives_interval -v 20
 # gpconfig -c gp_dispatch_keepalives_count -v 44
 
-psql -f set_resource_group.sql template1
+psql ${PSQL_OPTIONS} -f set_resource_group.sql template1

--- a/tpcds_tools/validate_gbb.sh
+++ b/tpcds_tools/validate_gbb.sh
@@ -180,11 +180,11 @@ validate_guc_settings() {
 
   gp_resource_group_memory_limit_x100=$(su - gpadmin -c 'gpconfig -s gp_resource_group_memory_limit' | grep "^Master" | awk '{ printf $3 * 100 }')
 
-  num_active_primary_segments=$(su - gpadmin -c "psql -d postgres -t -c \"select count(1) from gp_segment_configuration where content <> -1 and preferred_role = 'p'\"" | awk '{ printf $1 }')
+  num_active_primary_segments=$(su - gpadmin -c "psql ${PSQL_OPTIONS} -d postgres -t -c \"select count(1) from gp_segment_configuration where content <> -1 and preferred_role = 'p'\"" | awk '{ printf $1 }')
 
   rg_perseg_mem=$((((RAM_IN_MB * vm_overcommit_ratio / 100) + SWAP_IN_MB) * gp_resource_group_memory_limit_x100 / 100 / num_active_primary_segments))
 
-  max_expected_concurrent_queries=$(su - gpadmin -c "psql -d postgres -t -c \"SELECT concurrency FROM gp_toolkit.gp_resgroup_config where groupname = 'default_group'\"")
+  max_expected_concurrent_queries=$(su - gpadmin -c "psql ${PSQL_OPTIONS} -d postgres -t -c \"SELECT concurrency FROM gp_toolkit.gp_resgroup_config where groupname = 'default_group'\"")
 
   statement_mem=$((rg_perseg_mem / max_expected_concurrent_queries))
   max_statement_mem=$((RAM_IN_MB / max_expected_concurrent_queries))
@@ -199,7 +199,7 @@ validate_guc_settings() {
     mem_factor=117
   fi
   gp_vmem=$(((((SWAP_IN_MB + RAM_IN_MB) - (7680 + (5 / 100) * RAM_IN_MB)) / (mem_factor / 100))))
-  max_acting_primary_segments=$(su - gpadmin -c "psql -d postgres -t -c \
+  max_acting_primary_segments=$(su - gpadmin -c "psql ${PSQL_OPTIONS} -d postgres -t -c \
     \"with hostnames as ( \
       select distinct hostname \
       from gp_segment_configuration \

--- a/tpcds_variables.sh
+++ b/tpcds_variables.sh
@@ -5,6 +5,9 @@ export BENCH_ROLE="dsbench"
 
 # to connect directly to GP
 export PSQL_OPTIONS="-p 5432"
+# some of the tools like analyzedb donot have port option in arguments
+# they use default PostgreSQL environment variables
+export PGPORT=5432
 # to connect through pgbouncer
 #export PSQL_OPTIONS="-p 6543 -U dsbench"
 


### PR DESCRIPTION
- update all scripts to use PSQL_OPTIONS from tpcds_variables, so that if the default port change we should use the specified port in variable
- add PGPORT variable in tpcds_variables, so if the default port change its updateing PostgreSQL varaible to our specified port. Some of the tools like analyzedb use default PostgreSQL environment variables so port specification is not in comands-line arguments

Authored-by: Gaurab Dey <gaurabd@vmware.com>