### PR TITLE
Make the PGDATABASE env variable take effect

### DIFF
--- a/03_ddl/rollout.sh
+++ b/03_ddl/rollout.sh
@@ -82,11 +82,11 @@ DropRole="DROP ROLE IF EXISTS ${BENCH_ROLE}"
 CreateRole="CREATE ROLE ${BENCH_ROLE}"
 GrantSchemaPrivileges="GRANT ALL PRIVILEGES ON SCHEMA tpcds TO ${BENCH_ROLE}"
 GrantTablePrivileges="GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA tpcds TO ${BENCH_ROLE}"
-SetSearchPath="ALTER database gpadmin SET search_path=tpcds, \"\${user}\", public"
+SetSearchPath="ALTER database ${PGDATABASE} SET search_path=tpcds, \"\${user}\", public"
 
 start_log
 
-if [ "${BENCH_ROLE}" != "gpadmin" ]; then
+if [ "${BENCH_ROLE}" != "${ADMIN_USER}" ]; then
   log_time "Drop role ${BENCH_ROLE}"
   psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${DropRole}"
   log_time "Creating role ${BENCH_ROLE}"
@@ -97,7 +97,7 @@ if [ "${BENCH_ROLE}" != "gpadmin" ]; then
   psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${GrantTablePrivileges}"
 fi
 
-log_time "Set search_path for database gpadmin"
+log_time "Set search_path for database ${PGDATABASE}"
 psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${SetSearchPath}"
 
 print_log

--- a/04_load/analyze.sh
+++ b/04_load/analyze.sh
@@ -14,7 +14,7 @@ return_status="$?"
 if [ "$return_status" -eq "0" ]; then
   dbname="${PGDATABASE}"
   if [ "${dbname}" == "" ]; then
-    dbname="$ADMIN_USER"
+    dbname="${ADMIN_USER}"
   fi
 
   if [ "${PGPORT}" == "" ]; then

--- a/04_load/rollout.sh
+++ b/04_load/rollout.sh
@@ -76,7 +76,7 @@ stop_gpfdist
 max_id=$(ls ${PWD}/*.sql | tail -1)
 i=$(basename ${max_id} | awk -F '.' '{print $1}' | sed 's/^0*//')
 
-dbname="$PGDATABASE"
+dbname="${PGDATABASE}"
 if [ "${dbname}" == "" ]; then
   dbname="${ADMIN_USER}"
 fi

--- a/07_multi_user/test.sh
+++ b/07_multi_user/test.sh
@@ -76,17 +76,17 @@ for i in ${sql_dir}/*.sql; do
   export table_name
 
   if [ "${EXPLAIN_ANALYZE}" == "false" ]; then
-    log_time "psql ${PSQL_OPTIONS} -d gpadmin -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l"
+    log_time "psql ${PSQL_OPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l"
     tuples=$(
-      psql ${PSQL_OPTIONS} -d gpadmin -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l
+      psql ${PSQL_OPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l
       exit ${PIPESTATUS[0]}
     )
     tuples=$((tuples - 1))
   else
     myfilename=$(basename ${i})
     mylogfile="${TPC_DS_DIR}/log/${session_id}.${myfilename}.multi.explain_analyze.log"
-    log_time "psql ${PSQL_OPTIONS} -d gpadmin -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i}"
-    psql ${PSQL_OPTIONS} -d gpadmin -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f ${i} >${mylogfile}
+    log_time "psql ${PSQL_OPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i}"
+    psql ${PSQL_OPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f ${i} >${mylogfile}
     tuples="0"
   fi
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ These are the combined versions of TPC-DS and Greenplum:
 ## Setup
 ### Prerequisites
 
-1. A running Greenplum Database with `gpadmin` access
-2. `gpadmin` database is created
+1. A running Greenplum Database with `${ADMIN_USER}` access(default `gpadmin`)
+2. `${PGDATABASE}` database(default `gpadmin`) is created
 3. `root` access on the master node `mdw` for installing dependencies
 4. `ssh` connections between `mdw` and the segment nodes `sdw1..n`
 
@@ -60,7 +60,7 @@ The original source code is from http://tpc.org/tpc_documents_current_versions/c
 Visit the repo at https://github.com/pivotal/TPC-DS/releases and download the tarball to the `mdw` node.
 
 ```bash
-ssh gpadmin@mdw
+ssh ${ADMIN_USER}@mdw
 curl -LO https://github.com/pivotal/TPC-DS/archive/refs/tags/v3.3.0.tar.gz
 tar xzf v3.3.0.tar.gz
 mv TPC-DS-3.3.0 TPC-DS
@@ -68,10 +68,10 @@ mv TPC-DS-3.3.0 TPC-DS
 
 ## Usage
 
-To run the benchmark, login as `gpadmin` on `mdw:
+To run the benchmark, login as `${ADMIN_USER}` on `mdw`:
 
 ```
-ssh gpadmin@mdw
+ssh ${ADMIN_USER}@mdw
 cd ~/TPC-DS
 ./tpcds.sh
 ```
@@ -191,7 +191,7 @@ There are multiple steps running the benchmark and controlled by these variables
 - `RUN_SQL`: default `true`.
   It will run the power test of the benchmark.
 - `RUN_SINGLE_USER_REPORTS`: default `true`.
-  It will upload the results to the Greenplum database `gpadmin` under schema `tpcds_reports`.
+  It will upload the results to the Greenplum database `${PGDATABASE}` under schema `tpcds_reports`.
   These tables are required later on in the `RUN_SCORE` step.
   Recommend to keep it `true` if above step of `RUN_SQL` is `true`.
 - `RUN_MULTI_USER`: default `true`.
@@ -200,7 +200,7 @@ There are multiple steps running the benchmark and controlled by these variables
   `dsqgen` will sample the database to find proper filters.
   For very large database and a lot of streams, this process can take a long time (hours) to just generate the queries.
 - `RUN_MULTI_USER_REPORTS`: default `true`.
-  It will upload the results to the Greenplum database `gpadmin` under schema `tpcds_reports`.
+  It will upload the results to the Greenplum database `${PGDATABASE}` under schema `tpcds_reports`.
   Recommend to keep it `true` if above step of `RUN_MULTI_USER` is `true`.
 - `RUN_SCORE`: default `true`.
   It will query the results from `tpcds_reports` and compute the `QphDS` based on supported benchmark standard.

--- a/tpcds.sh
+++ b/tpcds.sh
@@ -15,7 +15,7 @@ export TPC_DS_DIR
 
 # Check that pertinent variables are set in the variable file.
 check_variables
-# Make sure this is being run as gpadmin
+# Make sure this is being run as ${ADMIN_USER}
 check_admin_user
 # Output admin user and multi-user count to standard out
 print_header

--- a/tpcds_tools/validate_gbb.sh
+++ b/tpcds_tools/validate_gbb.sh
@@ -167,7 +167,7 @@ validate_guc_settings() {
 
   echo
   echo "Verifying GUC settings for Greenplum"
-  if ! (su - gpadmin -c "gpstate") &>/dev/null; then
+  if ! (su - ${ADMIN_USER} -c "gpstate") &>/dev/null; then
     echo "ERROR: Greenplum is not running."
     _ERROR_FOUND=1
   fi
@@ -178,13 +178,13 @@ validate_guc_settings() {
 
   vm_overcommit_ratio=$(sysctl -n vm.overcommit_ratio)
 
-  gp_resource_group_memory_limit_x100=$(su - gpadmin -c 'gpconfig -s gp_resource_group_memory_limit' | grep "^Master" | awk '{ printf $3 * 100 }')
+  gp_resource_group_memory_limit_x100=$(su - ${ADMIN_USER} -c 'gpconfig -s gp_resource_group_memory_limit' | grep "^Master" | awk '{ printf $3 * 100 }')
 
-  num_active_primary_segments=$(su - gpadmin -c "psql -d postgres -t -c \"select count(1) from gp_segment_configuration where content <> -1 and preferred_role = 'p'\"" | awk '{ printf $1 }')
+  num_active_primary_segments=$(su - ${ADMIN_USER} -c "psql -d postgres -t -c \"select count(1) from gp_segment_configuration where content <> -1 and preferred_role = 'p'\"" | awk '{ printf $1 }')
 
   rg_perseg_mem=$((((RAM_IN_MB * vm_overcommit_ratio / 100) + SWAP_IN_MB) * gp_resource_group_memory_limit_x100 / 100 / num_active_primary_segments))
 
-  max_expected_concurrent_queries=$(su - gpadmin -c "psql -d postgres -t -c \"SELECT concurrency FROM gp_toolkit.gp_resgroup_config where groupname = 'default_group'\"")
+  max_expected_concurrent_queries=$(su - ${ADMIN_USER} -c "psql -d postgres -t -c \"SELECT concurrency FROM gp_toolkit.gp_resgroup_config where groupname = 'default_group'\"")
 
   statement_mem=$((rg_perseg_mem / max_expected_concurrent_queries))
   max_statement_mem=$((RAM_IN_MB / max_expected_concurrent_queries))
@@ -199,29 +199,29 @@ validate_guc_settings() {
     mem_factor=117
   fi
   gp_vmem=$(((((SWAP_IN_MB + RAM_IN_MB) - (7680 + (5 / 100) * RAM_IN_MB)) / (mem_factor / 100))))
-  max_acting_primary_segments=$(su - gpadmin -c "psql -d postgres -t -c \"with hostnames as ( select distinct hostname from gp_segment_configuration where content <> -1 order by hostname limit 1), content_ids as ( select content from gp_segment_configuration where hostname in ( select hostname from hostnames ) and preferred_role = 'p' and content <> -1), counts as ( select count(content) as mirrors_per_host, hostname from gp_segment_configuration where content in (select content from content_ids) and preferred_role = 'm' group by hostname) select count(content) + max(mirrors_per_host) as max_acting_primary_segments from content_ids, counts\"" | awk '{ printf $1 }')
+  max_acting_primary_segments=$(su - ${ADMIN_USER} -c "psql -d postgres -t -c \"with hostnames as ( select distinct hostname from gp_segment_configuration where content <> -1 order by hostname limit 1), content_ids as ( select content from gp_segment_configuration where hostname in ( select hostname from hostnames ) and preferred_role = 'p' and content <> -1), counts as ( select count(content) as mirrors_per_host, hostname from gp_segment_configuration where content in (select content from content_ids) and preferred_role = 'm' group by hostname) select count(content) + max(mirrors_per_host) as max_acting_primary_segments from content_ids, counts\"" | awk '{ printf $1 }')
   gp_vmem_protect_limit=$((gp_vmem / max_acting_primary_segments))
 
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_interconnect_queue_depth'" "Master  value: 16"
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_interconnect_queue_depth'" "Segment value: 16"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_interconnect_queue_depth'" "Master  value: 16"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_interconnect_queue_depth'" "Segment value: 16"
 
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_interconnect_snd_queue_depth'" "Master  value: 16"
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_interconnect_snd_queue_depth'" "Segment value: 16"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_interconnect_snd_queue_depth'" "Master  value: 16"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_interconnect_snd_queue_depth'" "Segment value: 16"
 
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_resource_group_memory_limit'" "Master  value: 0.85"
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_resource_group_memory_limit'" "Segment value: 0.85"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_resource_group_memory_limit'" "Master  value: 0.85"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_resource_group_memory_limit'" "Segment value: 0.85"
 
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s statement_mem'" "Master  value: ${statement_mem_with_unit}"
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s statement_mem'" "Segment value: ${statement_mem_with_unit}"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s statement_mem'" "Master  value: ${statement_mem_with_unit}"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s statement_mem'" "Segment value: ${statement_mem_with_unit}"
 
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s max_statement_mem'" "Master  value: ${max_statement_mem_with_unit}"
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s max_statement_mem'" "Segment value: ${max_statement_mem_with_unit}"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s max_statement_mem'" "Master  value: ${max_statement_mem_with_unit}"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s max_statement_mem'" "Segment value: ${max_statement_mem_with_unit}"
 
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_vmem_protect_limit'" "Master  value: ${gp_vmem_protect_limit}"
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_vmem_protect_limit'" "Segment value: ${gp_vmem_protect_limit}"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_vmem_protect_limit'" "Master  value: ${gp_vmem_protect_limit}"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_vmem_protect_limit'" "Segment value: ${gp_vmem_protect_limit}"
 
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_workfile_compression'" "Master  value: off"
-  cmd_val_contains "su - gpadmin -c 'gpconfig -s gp_workfile_compression'" "Segment value: off"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_workfile_compression'" "Master  value: off"
+  cmd_val_contains "su - ${ADMIN_USER} -c 'gpconfig -s gp_workfile_compression'" "Segment value: off"
 
 }
 


### PR DESCRIPTION
We defined two environment variables PGDATABASE and ADMIN_USER, but it had no effect. If we set PGDATABASE=postgres, we'll get an error: `TPC-DS/05_sql/101.dsbench.01.sql:25: ERROR: relation "store_returns"
 does not exist. LINE 5: from store_returns`

I found that there are about 40 places where the 'gpadmin' database and role names are hardcoded. In this commit, we remove the hardcoded 'gpadmin' database and role names, and use the env variable PGDATABASE or ADMIN_USER instead.