### PR TITLE
Remove hard-coded "gpadmin" database

### DIFF
--- a/07_multi_user/test.sh
+++ b/07_multi_user/test.sh
@@ -74,17 +74,17 @@ for i in "${sql_dir}"/*.sql; do
   table_name=$(basename "${i}" | awk -F '.' '{print $3}')
 
   if [ "${EXPLAIN_ANALYZE}" == "false" ]; then
-    log_time "psql -d gpadmin -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"\" -f ${i} | wc -l"
+    log_time "psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"\" -f ${i} | wc -l"
     tuples=$(
-      psql -d gpadmin -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f "${i}" | wc -l
+      psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f "${i}" | wc -l
       exit "${PIPESTATUS[0]}"
     )
     tuples=$((tuples - 1))
   else
     myfilename=$(basename "${i}")
     mylogfile="${TPC_DS_DIR}/log/${session_id}.${myfilename}.multi.explain_analyze.log"
-    log_time "psql -d gpadmin -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i}"
-    psql -d gpadmin -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f "${i}" > "${mylogfile}"
+    log_time "psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i}"
+    psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f "${i}" > "${mylogfile}"
     tuples="0"
   fi
 


### PR DESCRIPTION
This PR is to avoid error while running TPCDS due to hard-coded "gpadmin" database, which is usually different that default database (postgres or others..) 

We can leave the user choose the right PGOPTIONS, and PGDATABASE.