### PR TITLE
GPV-1714 Add quite mode option when command output required

### DIFF
--- a/01_gen_data/rollout.sh
+++ b/01_gen_data/rollout.sh
@@ -13,7 +13,7 @@ fi
 function get_count_generate_data() {
   count="0"
   while read -r i; do
-    next_count=$(ssh -o ConnectTimeout=0 -n -f "${i}" "bash -c 'ps -ef | grep generate_data.sh | grep -v grep | wc -l'" 2>&1 || true)
+    next_count=$(ssh "${ADDITION_SSH_OPTIONS}" -o ConnectTimeout=0 -n -f "${i}" "bash -c 'ps -ef | grep generate_data.sh | grep -v grep | wc -l'" 2>&1 || true)
     check="^[0-9]+$"
     if ! [[ "${next_count}" =~ ${check} ]]; then
       next_count="1"

--- a/02_init/rollout.sh
+++ b/02_init/rollout.sh
@@ -25,18 +25,18 @@ EOF
     # don't overwrite the master.  Only needed on single node installs
     shortname=$(echo "${ext_host}" | awk -F '.' '{print $1}')
     if [ "${MASTER_HOST}" != "${shortname}" ]; then
-      bashrc_exists=$(ssh -n "${ext_host}" "find ~ -name .bashrc | grep -c .")
+      bashrc_exists=$(ssh "${ADDITION_SSH_OPTIONS}" -n "${ext_host}" "find ~ -name .bashrc | grep -c .")
       if [ "${bashrc_exists}" -eq 0 ]; then
         echo "copy new .bashrc to ${ext_host}:~${ADMIN_USER}"
         scp "${PWD}"/segment_bashrc "${ext_host}":~"${ADMIN_USER}"/.bashrc
       else
-        count=$(ssh -n "${ext_host}" "grep -c greenplum_path ~/.bashrc || true")
+        count=$(ssh "${ADDITION_SSH_OPTIONS}" -n "${ext_host}" "grep -c greenplum_path ~/.bashrc || true")
         if [ "${count}" -eq 0 ]; then
           echo "Adding greenplum_path to ${ext_host} .bashrc"
           # shellcheck disable=SC2029
           ssh "${ext_host}" "echo \"source ${GREENPLUM_PATH}\" >> ~/.bashrc"
         fi
-        count=$(ssh -n "${ext_host}" "grep -c LD_PRELOAD ~/.bashrc || true")
+        count=$(ssh "${ADDITION_SSH_OPTIONS}" -n "${ext_host}" "grep -c LD_PRELOAD ~/.bashrc || true")
         if [ "${count}" -eq 0 ]; then
           echo "Adding LD_PRELOAD to ${ext_host} .bashrc"
           # shellcheck disable=SC2029

--- a/tpcds_variables.sh
+++ b/tpcds_variables.sh
@@ -10,6 +10,11 @@ export PGPORT="5432"
 # Add additional PostgreSQL refer:
 # https://www.postgresql.org/docs/current/libpq-envars.html
 
+# when OS configured with pre-login messages causing string pollution in
+# command output value; we should use ssh quite mode is we are expecting
+# command output. Additional flags can be added
+export ADDITION_SSH_OPTIONS="-q"
+
 # benchmark options
 export GEN_DATA_SCALE="1"
 export MULTI_USER_COUNT="2"


### PR DESCRIPTION
- when script is performing actions based in ssh command output values we should run it in quite mode to avoid pollution becaue of pre-loging messages from	`ssh banner` or post logning messages from `/etc/motd`

Authored-by: Gaurab Dey <gaurabd@vmware.com>