### PR TITLE
Introduce step header and footer with step elapsed time

### DIFF
--- a/00_compile_tpcds/rollout.sh
+++ b/00_compile_tpcds/rollout.sh
@@ -44,4 +44,4 @@ copy_tpc
 copy_queries
 print_log "1" "${schema_name}" "${table_name}" "0"
 
-echo "Finished ${step}"
+end_step $step

--- a/01_gen_data/rollout.sh
+++ b/01_gen_data/rollout.sh
@@ -98,4 +98,4 @@ cd "${PWD}"
 
 print_log "1" "tpcds" "gen_data" "0"
 
-echo "Finished ${step}"
+end_step $step

--- a/02_init/rollout.sh
+++ b/02_init/rollout.sh
@@ -118,4 +118,4 @@ copy_config
 
 print_log "1" "${schema_name}" "${table_name}" "0"
 
-echo "Finished ${step}"
+end_step $step

--- a/03_ddl/rollout.sh
+++ b/03_ddl/rollout.sh
@@ -97,4 +97,4 @@ psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${SetSearchPath}"
 
 print_log "${id}" "${schema_name}" "${table_name}" "0"
 
-echo "Finished ${step}"
+end_step $step

--- a/04_load/rollout.sh
+++ b/04_load/rollout.sh
@@ -120,4 +120,4 @@ print_log "${id}" "${schema_name}" "${table_name}" 0
 log_time "collecting schema and statistics dump using gpsd ..."
 gpsd "${dbname}" > "${TPC_DS_DIR}/log/gpsd.${dbname}.sql"
 
-echo "Finished ${step}"
+end_step $step

--- a/05_sql/rollout.sh
+++ b/05_sql/rollout.sh
@@ -30,4 +30,4 @@ for i in "${PWD}"/*."${BENCH_ROLE}".*.sql; do
   done
 done
 
-echo "Finished ${step}"
+end_step $step

--- a/06_single_user_reports/rollout.sh
+++ b/06_single_user_reports/rollout.sh
@@ -47,4 +47,4 @@ echo "Queries"
 echo "********************************************************************************"
 psql -F $'\t' -A -v ON_ERROR_STOP=1 -P pager=off -f "${PWD}"/queries_report.sql
 echo ""
-echo "Finished ${step}"
+end_step $step

--- a/07_multi_user/rollout.sh
+++ b/07_multi_user/rollout.sh
@@ -4,7 +4,7 @@ set -e
 
 PWD=$(get_pwd "${BASH_SOURCE[0]}")
 
-step="multi_user_reports"
+step="multi_user"
 init_log "${step}"
 
 if [ "${MULTI_USER_COUNT}" -eq "0" ]; then

--- a/07_multi_user/rollout.sh
+++ b/07_multi_user/rollout.sh
@@ -4,6 +4,9 @@ set -e
 
 PWD=$(get_pwd "${BASH_SOURCE[0]}")
 
+step="multi_user_reports"
+init_log "${step}"
+
 if [ "${MULTI_USER_COUNT}" -eq "0" ]; then
   echo "MULTI_USER_COUNT set at 0 so exiting..."
   exit 0
@@ -92,3 +95,5 @@ if [ "${file_count}" -ne "${MULTI_USER_COUNT}" ]; then
 fi
 
 rm -f "${TPC_DS_DIR}"/log/end_testing_*.log # remove the counter log file if successful.
+
+end_step $step

--- a/07_multi_user/test.sh
+++ b/07_multi_user/test.sh
@@ -8,7 +8,8 @@ session_id="${1}"
 
 step="testing_${session_id}"
 
-init_log "${step}"
+logfile="rollout_${step}.log"
+rm -f "${TPC_DS_DIR}/log/${logfile}"
 
 sql_dir="${PWD}/${session_id}"
 
@@ -92,4 +93,5 @@ for i in "${sql_dir}"/*.sql; do
   print_log "${id}" "${schema_name}" "${table_name}" "${tuples}"
 done
 
-end_step "${step}"
+logfile=end_${step}.log
+touch "${TPC_DS_DIR}/log/${logfile}"

--- a/08_multi_user_reports/rollout.sh
+++ b/08_multi_user_reports/rollout.sh
@@ -28,4 +28,4 @@ psql -v ON_ERROR_STOP=1 -t -A -c "select 'analyze ' || n.nspname || '.' || c.rel
 psql -v ON_ERROR_STOP=1 -F $'\t' -A -P pager=off -f "${PWD}"/detailed_report.sql
 echo ""
 
-echo "Finished ${step}"
+end_step $step

--- a/09_score/rollout.sh
+++ b/09_score/rollout.sh
@@ -70,4 +70,4 @@ printf "Score\t\t\t%d\n" "${SCORE_2_2_0}"
 printf -- '-%.0s' {1..80}
 printf "\n"
 
-echo "Finished ${step}"
+end_step $step

--- a/functions.sh
+++ b/functions.sh
@@ -180,6 +180,7 @@ function get_version() {
 export -f get_version
 
 function init_log() {
+  print_step_header "${1}"
   logfile="rollout_${1}.log"
   rm -f "${TPC_DS_DIR}/log/${logfile}"
 }
@@ -224,6 +225,7 @@ export -f print_log
 function end_step() {
   local logfile=end_${1}.log
   touch "${TPC_DS_DIR}/log/${logfile}"
+  print_step_footer "${1}"
 }
 export -f end_step
 
@@ -240,3 +242,37 @@ function create_hosts_file() {
   psql -v ON_ERROR_STOP=1 -t -A -c "${SQL_QUERY}" -o "${TPC_DS_DIR}"/segment_hosts.txt
 }
 export -f create_hosts_file
+
+function print_step_header() {
+  STEP=${1}
+  SECONDS=0
+
+  cat << EOF
+
+######################################################################
+                                START
+----------------------------------------------------------------------
+STEP .......... : ${STEP}
+TIMESTAMP ..... : $(date)
+----------------------------------------------------------------------
+
+EOF
+}
+export -f print_step_header
+
+function print_step_footer() {
+  STEP=${1}
+  secs=$SECONDS
+
+  cat << EOF
+
+----------------------------------------------------------------------
+                               FINISHED
+----------------------------------------------------------------------
+STEP .......... : ${STEP}
+TIMESTAMP ..... : $(date)
+ELAPSED TIME .. : $(printf '%02dh:%02dm:%02ds\n' $((secs / 3600)) $((secs % 3600 / 60)) $((secs % 60)))
+######################################################################
+EOF
+}
+export -f print_step_footer

--- a/rollout.sh
+++ b/rollout.sh
@@ -41,7 +41,6 @@ echo "RUN_MULTI_USER_REPORTS: ${RUN_MULTI_USER_REPORTS}"
 echo "BENCH_ROLE: ${BENCH_ROLE}"
 echo "GPFDIST_LOCATION: ${GPFDIST_LOCATION}"
 echo "############################################################################"
-echo ""
 
 # We assume that the flag variable names are consistent with the corresponding directory names.
 # For example, `00_compile_tpcds directory` name will be used to get `true` or `false` value from `RUN_COMPILE_TPCDS` in `tpcds_variables.sh`.
@@ -55,10 +54,11 @@ for i in "${PWD}"/0*/; do
   run_flag=${!flag_name}
 
   if [ "${run_flag}" == "true" ]; then
-    echo "Run ${i}/rollout.sh"
-    "${i}"/rollout.sh
+    echo ""
+    echo "Run ${i}rollout.sh"
+    "${i}"rollout.sh
   elif [ "${run_flag}" == "false" ]; then
-    echo "Skip ${i}/rollout.sh"
+    echo "Skip ${i}rollout.sh"
   else
     echo "Aborting script because ${flag_name} is not properly specified: must be either \"true\" or \"false\"."
     exit 1


### PR DESCRIPTION
I find it useful to know how long each of the TPC-DS steps take. This PR provides a header and footer for each step. The bash shell SECONDS variable is utilized to track the duration between the `init_log` and `end_step` function calls. Here is an example of the output for the `gen_data` step. 

```
######################################################################
                                START
----------------------------------------------------------------------
STEP .......... : gen_data
TIMESTAMP ..... : Tue Oct 10 22:41:50 PDT 2023
----------------------------------------------------------------------
```

_step output intentionally elided_

```
----------------------------------------------------------------------
                               FINISHED
----------------------------------------------------------------------
STEP .......... : gen_data
TIMESTAMP ..... : Tue Oct 10 23:12:07 PDT 2023
ELAPSED TIME .. : 00h:30m:17s
######################################################################
```