### PR TITLE
fix set_segment_bashrc only works on oneline file

### DIFF
--- a/01_gen_data/rollout.sh
+++ b/01_gen_data/rollout.sh
@@ -79,7 +79,7 @@ if [ "${GEN_NEW_DATA}" == "true" ]; then
   minutes=0
   echo -ne "Generating data duration: "
   while [ "$count" -gt "0" ]; do
-    echo -ne "${minutes} minute(s)"
+    echo -ne "${minutes} minute(s)\n"
     sleep 60
     minutes=$((minutes + 1))
     get_count_generate_data

--- a/01_gen_data/rollout.sh
+++ b/01_gen_data/rollout.sh
@@ -78,9 +78,7 @@ if [ "${GEN_NEW_DATA}" == "true" ]; then
   echo "Now generating data.  This may take a while."
   minutes=0
   echo -ne "Generating data duration: "
-  tput sc
   while [ "$count" -gt "0" ]; do
-    tput rc
     echo -ne "${minutes} minute(s)"
     sleep 60
     minutes=$((minutes + 1))

--- a/02_init/rollout.sh
+++ b/02_init/rollout.sh
@@ -34,13 +34,13 @@ EOF
         if [ "${count}" -eq 0 ]; then
           echo "Adding greenplum_path to ${ext_host} .bashrc"
           # shellcheck disable=SC2029
-          ssh -q "${ext_host}" "echo \"source ${GREENPLUM_PATH}\" >> ~/.bashrc"
+          ssh -q -n "${ext_host}" "echo \"source ${GREENPLUM_PATH}\" >> ~/.bashrc"
         fi
         count=$(ssh -q -n "${ext_host}" "grep -c LD_PRELOAD ~/.bashrc || true")
         if [ "${count}" -eq 0 ]; then
           echo "Adding LD_PRELOAD to ${ext_host} .bashrc"
           # shellcheck disable=SC2029
-          ssh -q "${ext_host}" "echo \"export LD_PRELOAD=${LD_PRELOAD}\" >> ~/.bashrc"
+          ssh -q -n "${ext_host}" "echo \"export LD_PRELOAD=${LD_PRELOAD}\" >> ~/.bashrc"
         fi
       fi
     fi

--- a/07_multi_user/rollout.sh
+++ b/07_multi_user/rollout.sh
@@ -76,7 +76,7 @@ echo "Now executing queries. This may take a while."
 minutes=0
 echo -n "Multi-user query duration: "
 while [ "$(get_running_jobs_count)" -gt 0 ]; do
-  echo -n "${minutes} minute(s)"
+  echo -n "${minutes} minute(s)\n"
   sleep 60
   minutes=$((minutes + 1))
 done

--- a/07_multi_user/rollout.sh
+++ b/07_multi_user/rollout.sh
@@ -75,9 +75,7 @@ done
 echo "Now executing queries. This may take a while."
 minutes=0
 echo -n "Multi-user query duration: "
-tput sc
 while [ "$(get_running_jobs_count)" -gt 0 ]; do
-  tput rc
   echo -n "${minutes} minute(s)"
   sleep 60
   minutes=$((minutes + 1))


### PR DESCRIPTION
- remove `tput` command, it doesn't works in non-interactive shell
- fix create set_segment_bashrc function bug: https://github.com/koalaman/shellcheck/wiki/SC2095, it will only execute one line in segment_files.