### PR TITLE
exit when the GREENPLUM_PATH not set

### DIFF
--- a/02_init/rollout.sh
+++ b/02_init/rollout.sh
@@ -33,6 +33,10 @@ EOF
         count=$(ssh -q -n "${ext_host}" "grep -c greenplum_path ~/.bashrc || true")
         if [ "${count}" -eq 0 ]; then
           echo "Adding greenplum_path to ${ext_host} .bashrc"
+          if [[ -z $GREENPLUM_PATH ]]; then
+            echo "Need export GREENPLUM_PATH variable"
+            exit 1
+          fi
           # shellcheck disable=SC2029
           ssh -q -n "${ext_host}" "echo \"source ${GREENPLUM_PATH}\" >> ~/.bashrc"
         fi


### PR DESCRIPTION
if GREENPLUM_PATH is not set. 
this function will write a `source` command to the `bashrc` file without parameter
```
source 
```
