### PR TITLE
Fix issues with gpsd default user

### DIFF
--- a/04_load/rollout.sh
+++ b/04_load/rollout.sh
@@ -118,6 +118,6 @@ id=$(basename "${max_id}" | awk -F '.' '{print $1}' | sed 's/^0*//')
 print_log "${id}" "${schema_name}" "${table_name}" 0
 
 log_time "collecting schema and statistics dump using gpsd ..."
-gpsd "${dbname}" > "${TPC_DS_DIR}/log/gpsd.${dbname}.sql"
+gpsd -U "${ADMIN_USER}" "${dbname}" > "${TPC_DS_DIR}/log/gpsd.${dbname}.sql"
 
 end_step $step


### PR DESCRIPTION
- workaround for gpsd to make sure it uses `ADMIN_USER` not `root` during collecting data statistics. For more detail: 
https://github.com/greenplum-db/gpdb/pull/16966

Authored-by: Gaurab Dey <gaurabd@vmware.com>