### PR TITLE
Add support to compile in newer gcc on RHEL9

### DIFF
--- a/00_compile_tpcds/rollout.sh
+++ b/00_compile_tpcds/rollout.sh
@@ -13,7 +13,7 @@ function make_tpc() {
   #compile the tools
   cd "${PWD}"/tools
   rm -f ./*.o
-  ADDITIONAL_CFLAGS_OPTION="-g -Wno-unused-function -Wno-unused-but-set-variable -Wno-format" make
+  ADDITIONAL_CFLAGS_OPTION="-Wl,--allow-multiple-definition -g -Wno-unused-function -Wno-unused-but-set-variable -Wno-format" make
   cd ..
 }
 


### PR DESCRIPTION
- compile step failed with collect2 error caused by multiple definitions

```
multiple definition of `nItemIndex' ...
multiple definition of `g_s_web_ord ...
```