### PR TITLE
Make the PGDATABASE env variable take effect

### DIFF
--- a/03_ddl/rollout.sh
+++ b/03_ddl/rollout.sh
@@ -77,11 +77,11 @@ DropRole="DROP ROLE IF EXISTS ${BENCH_ROLE}"
 CreateRole="CREATE ROLE ${BENCH_ROLE}"
 GrantSchemaPrivileges="GRANT ALL PRIVILEGES ON SCHEMA tpcds TO ${BENCH_ROLE}"
 GrantTablePrivileges="GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA tpcds TO ${BENCH_ROLE}"
-SetSearchPath="ALTER database ${ADMIN_USER} SET search_path=tpcds, \"\${ADMIN_USER}\", public"
+SetSearchPath="ALTER database ${ADMIN_USER} SET search_path=tpcds, \"\${user}\", public"
 
 start_log
 
-if [ "${BENCH_ROLE}" != "gpadmin" ]; then
+if [ "${BENCH_ROLE}" != "${ADMIN_USER}" ]; then
   log_time "Drop role ${BENCH_ROLE}"
   psql -v ON_ERROR_STOP=0 -q -P pager=off -c "${DropRole}"
   log_time "Creating role ${BENCH_ROLE}"

--- a/03_ddl/rollout.sh
+++ b/03_ddl/rollout.sh
@@ -77,7 +77,7 @@ DropRole="DROP ROLE IF EXISTS ${BENCH_ROLE}"
 CreateRole="CREATE ROLE ${BENCH_ROLE}"
 GrantSchemaPrivileges="GRANT ALL PRIVILEGES ON SCHEMA tpcds TO ${BENCH_ROLE}"
 GrantTablePrivileges="GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA tpcds TO ${BENCH_ROLE}"
-SetSearchPath="ALTER database ${ADMIN_USER} SET search_path=tpcds, \"\${user}\", public"
+SetSearchPath="ALTER database ${ADMIN_USER} SET search_path=tpcds, \"\${ADMIN_USER}\", public"
 
 start_log
 

--- a/04_load/rollout.sh
+++ b/04_load/rollout.sh
@@ -80,7 +80,7 @@ print_log "${id}" "${schema_name}" "${table_name}" 0
 
 stop_gpfdist
 
-dbname="$PGDATABASE"
+dbname="${PGDATABASE}"
 if [ "${dbname}" == "" ]; then
   dbname="${ADMIN_USER}"
 fi

--- a/07_multi_user/test.sh
+++ b/07_multi_user/test.sh
@@ -75,17 +75,17 @@ for i in "${sql_dir}"/*.sql; do
   table_name=$(basename "${i}" | awk -F '.' '{print $3}')
 
   if [ "${EXPLAIN_ANALYZE}" == "false" ]; then
-    log_time "psql ${PSQL_OPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l"
+    log_time "psql ${PGOPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l"
     tuples=$(
-      psql "${PSQL_OPTIONS}" -d "${PGDATABASE}" -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f "${i}" | wc -l
+      psql "${PGOPTIONS}" -d "${PGDATABASE}" -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f "${i}" | wc -l
       exit "${PIPESTATUS[0]}"
     )
     tuples=$((tuples - 1))
   else
     myfilename=$(basename "${i}")
     mylogfile="${TPC_DS_DIR}/log/${session_id}.${myfilename}.multi.explain_analyze.log"
-    log_time "psql ${PSQL_OPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i}"
-    psql "${PSQL_OPTIONS}" -d "${PGDATABASE}" -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f "${i}" > ${mylogfile}
+    log_time "psql ${PGOPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i}"
+    psql "${PGOPTIONS}" -d "${PGDATABASE}" -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f "${i}" > ${mylogfile}
     tuples="0"
   fi
 

--- a/07_multi_user/test.sh
+++ b/07_multi_user/test.sh
@@ -75,17 +75,17 @@ for i in "${sql_dir}"/*.sql; do
   table_name=$(basename "${i}" | awk -F '.' '{print $3}')
 
   if [ "${EXPLAIN_ANALYZE}" == "false" ]; then
-    log_time "psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"\" -f ${i} | wc -l"
+    log_time "psql ${PSQL_OPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f ${i} | wc -l"
     tuples=$(
-      psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f "${i}" | wc -l
+      psql "${PSQL_OPTIONS}" -d "${PGDATABASE}" -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="" -f "${i}" | wc -l
       exit "${PIPESTATUS[0]}"
     )
     tuples=$((tuples - 1))
   else
     myfilename=$(basename "${i}")
     mylogfile="${TPC_DS_DIR}/log/${session_id}.${myfilename}.multi.explain_analyze.log"
-    log_time "psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i}"
-    psql -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f "${i}" > "${mylogfile}"
+    log_time "psql ${PSQL_OPTIONS} -d ${PGDATABASE} -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE=\"EXPLAIN ANALYZE\" -f ${i}"
+    psql "${PSQL_OPTIONS}" -d "${PGDATABASE}" -v ON_ERROR_STOP=1 -A -q -t -P pager=off -v EXPLAIN_ANALYZE="EXPLAIN ANALYZE" -f "${i}" > ${mylogfile}
     tuples="0"
   fi
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Visit the repo at https://github.com/pivotal/TPC-DS/releases and download the ta
 
 ```bash
 ssh ${ADMIN_USER}@mdw
-curl -LO https://github.com/pivotal/TPC-DS/archive/refs/tags/v3.3.0.tar.gz
-tar xzf v3.3.0.tar.gz
-mv TPC-DS-3.3.0 TPC-DS
+curl -LO https://github.com/pivotal/TPC-DS/archive/refs/tags/v3.7.0.tar.gz
+tar xzf v3.7.0.tar.gz
+mv TPC-DS-3.7.0 TPC-DS
 ```
 **NOTE:** default `ADMIN_USER` is assumed to be `gpadmin`
 
@@ -96,6 +96,9 @@ This is the default example at [tpcds_variables.sh](https://github.com/pivotal/T
 ```shell
 # environment options
 ADMIN_USER=`whoami`
+BENCH_ROLE="dsbench"
+PGOPTIONS=""
+PGDATABASE=`whoami`
 
 # benchmark options
 GEN_DATA_SCALE="1"
@@ -145,6 +148,8 @@ In most cases, we just leave them to the default.
 export PGPORT="6543"
 # Add additional PostgreSQL refer:
 # https://www.postgresql.org/docs/current/libpq-envars.html
+export PGOPTIONS=""
+export PGDATABASE="${ADMIN_USER}"
 ```
 
 TPC-DS uses `psql` command, which interally uses `libpq`, to connect to the database.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ These are the combined versions of TPC-DS and Greenplum:
 ## Setup
 ### Prerequisites
 
-1. A running Greenplum Database with `gpadmin` access
-2. `gpadmin` database is created
+1. A running Greenplum Database with `${ADMIN_USER}` access(default `gpadmin`)
+2. `${PGDATABASE}` database(default `gpadmin`) is created
 3. `root` access on the master node `mdw` for installing dependencies
 4. `ssh` connections between `mdw` and the segment nodes `sdw1..n`
 
@@ -67,21 +67,23 @@ The original source code is from http://tpc.org/tpc_documents_current_versions/c
 Visit the repo at https://github.com/pivotal/TPC-DS/releases and download the tarball to the `mdw` node.
 
 ```bash
-ssh gpadmin@mdw
-curl -LO https://github.com/pivotal/TPC-DS/archive/refs/tags/v3.7.0.tar.gz
-tar xzf v3.7.0.tar.gz
-mv TPC-DS-3.7.0 TPC-DS
+ssh ${ADMIN_USER}@mdw
+curl -LO https://github.com/pivotal/TPC-DS/archive/refs/tags/v3.3.0.tar.gz
+tar xzf v3.3.0.tar.gz
+mv TPC-DS-3.3.0 TPC-DS
 ```
+**NOTE:** default `ADMIN_USER` is assumed to be `gpadmin`
 
 ## Usage
 
-To run the benchmark, login as `gpadmin` on `mdw`:
+To run the benchmark, login as `${ADMIN_USER}` on `mdw`:
 
 ```
-ssh gpadmin@mdw
+ssh ${ADMIN_USER}@mdw
 cd ~/TPC-DS
 ./tpcds.sh
 ```
+**NOTE:** default `ADMIN_USER` is assumed to be `gpadmin`
 
 By default, it will run a scale 1 (1G) and with 2 concurrent users, from data generation to score computation.
 
@@ -218,7 +220,7 @@ There are multiple steps running the benchmark and controlled by these variables
 - `RUN_SQL`: default `true`.
   It will run the power test of the benchmark.
 - `RUN_SINGLE_USER_REPORTS`: default `true`.
-  It will upload the results to the Greenplum database `gpadmin` under schema `tpcds_reports`.
+  It will upload the results to the Greenplum database `${PGDATABASE}` under schema `tpcds_reports`.
   These tables are required later on in the `RUN_SCORE` step.
   Recommend to keep it `true` if above step of `RUN_SQL` is `true`.
 - `RUN_MULTI_USER`: default `true`.
@@ -227,7 +229,7 @@ There are multiple steps running the benchmark and controlled by these variables
   `dsqgen` will sample the database to find proper filters.
   For very large database and a lot of streams, this process can take a long time (hours) to just generate the queries.
 - `RUN_MULTI_USER_REPORTS`: default `true`.
-  It will upload the results to the Greenplum database `gpadmin` under schema `tpcds_reports`.
+  It will upload the results to the Greenplum database `${PGDATABASE}` under schema `tpcds_reports`.
   Recommend to keep it `true` if above step of `RUN_MULTI_USER` is `true`.
 - `RUN_SCORE`: default `true`.
   It will query the results from `tpcds_reports` and compute the `QphDS` based on supported benchmark standard.

--- a/tpcds.sh
+++ b/tpcds.sh
@@ -16,7 +16,9 @@ export TPC_DS_DIR
 
 # Check that pertinent variables are set in the variable file.
 check_variables
-# Output user and multi-user count to standard out
+# Make sure this is being run as ${ADMIN_USER}
+check_admin_user
+# Output admin user and multi-user count to standard out
 print_header
 
 # run the benchmark

--- a/tpcds_variables.sh
+++ b/tpcds_variables.sh
@@ -16,6 +16,8 @@ export PGPORT="5432"
 # export PGPORT="6543"
 # Add additional PostgreSQL refer:
 # https://www.postgresql.org/docs/current/libpq-envars.html
+export PGOPTIONS=""
+export PGDATABASE="${ADMIN_USER}"
 
 # benchmark options
 export GEN_DATA_SCALE="1"


### PR DESCRIPTION
We defined two environment variables PGDATABASE and ADMIN_USER, but it had no effect. If we set PGDATABASE=postgres, we'll get an error: `TPC-DS/05_sql/101.dsbench.01.sql:25: ERROR: relation "store_returns"
 does not exist. LINE 5: from store_returns`

I found that there are about 40 places where the 'gpadmin' database and role names are hardcoded. In this commit, we remove the hardcoded 'gpadmin' database and role names, and use the env variable PGDATABASE or ADMIN_USER instead.